### PR TITLE
Fix latency

### DIFF
--- a/src/FFTAnalyzer.cpp
+++ b/src/FFTAnalyzer.cpp
@@ -45,16 +45,17 @@ void FFTAnalyzer::calculateWindow()
 {
 	// Hann Window function
 	// used to prepare the PCM data for FFT
-	for (int i=0; i<NUM_SAMPLES; ++i) {
-		m_window[i] = 0.5f * (1 - qCos((2 * M_PI * i) / (NUM_SAMPLES - 1)));
+    for (int i=0; i<NUM_SAMPLES; ++i) {
+        m_window[i] = 0.5f * (1 - qCos((2 * M_PI * i) / (NUM_SAMPLES - 1)));
 	}
 }
 
 void FFTAnalyzer::calculateFFT(bool lowSoloMode)
 {
 	// apply window:
-	for (int i=0; i < NUM_SAMPLES; ++i) {
-		m_buffer[i] = m_inputBuffer.at(i) * m_window[i];
+    int bufferOffset = m_inputBuffer.getCapacity() - NUM_SAMPLES;
+    for (int i=0; i < NUM_SAMPLES; ++i) {
+        m_buffer[i] = m_inputBuffer.at(i + bufferOffset) * m_window[i];
 	}
 
 	// apply FFT:

--- a/src/FFTAnalyzer.cpp
+++ b/src/FFTAnalyzer.cpp
@@ -45,17 +45,17 @@ void FFTAnalyzer::calculateWindow()
 {
 	// Hann Window function
 	// used to prepare the PCM data for FFT
-    for (int i=0; i<NUM_SAMPLES; ++i) {
-        m_window[i] = 0.5f * (1 - qCos((2 * M_PI * i) / (NUM_SAMPLES - 1)));
+	for (int i=0; i<NUM_SAMPLES; ++i) {
+		m_window[i] = 0.5f * (1 - qCos((2 * M_PI * i) / (NUM_SAMPLES - 1)));
 	}
 }
 
 void FFTAnalyzer::calculateFFT(bool lowSoloMode)
 {
 	// apply window:
-    int bufferOffset = m_inputBuffer.getCapacity() - NUM_SAMPLES;
-    for (int i=0; i < NUM_SAMPLES; ++i) {
-        m_buffer[i] = m_inputBuffer.at(i + bufferOffset) * m_window[i];
+	int bufferOffset = m_inputBuffer.getCapacity() - NUM_SAMPLES;
+	for (int i=0; i < NUM_SAMPLES; ++i) {
+		m_buffer[i] = m_inputBuffer.at(i + bufferOffset) * m_window[i];
 	}
 
 	// apply FFT:


### PR DESCRIPTION
A wrong index to a buffer caused a ~300 ms delay. The latency between a sound and an OSC packet being sent is now back to under 80 ms on Win 10 with a normal USB soundcard.